### PR TITLE
Bugfix: Change from OneToOne to ManyToOne relationship with Roles in UserEntity

### DIFF
--- a/src/auth-service/src/main/java/com/dialosoft/auth/persistence/entity/UserEntity.java
+++ b/src/auth-service/src/main/java/com/dialosoft/auth/persistence/entity/UserEntity.java
@@ -38,7 +38,7 @@ public class UserEntity {
     @Builder.Default
     private Boolean disable = Boolean.FALSE;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "role_id", referencedColumnName = "id")
     private RoleEntity role;
 


### PR DESCRIPTION


# Pull Request

## Description

Change from OneToOne to ManyToOne relationship with Roles in UserEntity due to if we use OneToOne we cannot make 1 role to have multiple users and 1 user must have only 1 role. Before of this solution when trying to register a 2 user, it gives error due to this,

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
